### PR TITLE
Add uninstaller, runtime check for minimum WordPress version.

### DIFF
--- a/admin-language-per-user.php
+++ b/admin-language-per-user.php
@@ -2,17 +2,19 @@
 /**
  Plugin Name: Admin Language Per User
  Description: Lets you have your backend administration panel in english or any installed language, even if the rest of your blog is translated into another language. Language preferences can be set per user basis in user profile screen.  
- Version: 1.0.0
+ Version: 1.0.1
  Author: unclego 
  License: GPLv3
  License URI: http://www.gnu.org/licenses/gpl.html
+ Text Domain: admin-language-per-user
+ Domain Path: /languages
  Tags: translation, translations, i18n, admin, english, localization, backend
  Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6G9LJ5H8GHQ3S
  */
 
 /**
  * Admin Language Per User
- * Copyright (C) 2016, Unlego
+ * Copyright (C) 2016, Unclego
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +29,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 namespace admin_language_per_user;
+
+if (!defined('ABSPATH')) { exit; } // Disallow direct HTTP access.
+
 require_once( ABSPATH . 'wp-admin/includes/translation-install.php' );
 
 /**
@@ -36,11 +42,15 @@ require_once( ABSPATH . 'wp-admin/includes/translation-install.php' );
  *
  */
 class Admin_Language {
+	/**
+	 * The option name used internally.
+	 *
+	 * @var string
+	 */
 	const meta_name = 'admin_language';
 
 	/**
 	 * Hooks setup
-	 * 
 	 */
 	public static function _loader() {
 		add_action( 'plugins_loaded', array(get_class(), 'plugins_loaded') );
@@ -49,13 +59,75 @@ class Admin_Language {
 		add_action( 'edit_user_profile', array(get_class(), 'user_profile') );
 		add_action( 'personal_options_update', array(get_class(), 'process_user_option_update') );
 		add_action( 'edit_user_profile_update', array(get_class(), 'process_user_option_update') );
+
+		register_activation_hook( __FILE__, array(get_class(), 'activate') );
 	}
+
+	/**
+	 * Method to run when the plugin is activated by a user in the
+	 * WordPress Dashboard admin screen.
+	 *
+	 * @uses Admin_Language::checkPrereqs()
+	 *
+	 * @return void
+	 */
+	public static function activate () {
+		self::checkPrereqs();
+	}
+
+	/**
+	 * Checks system requirements and exits if they are not met.
+	 *
+	 * This first checks to ensure minimum WordPress and PHP versions
+	 * have been satisfied. If not, the plugin deactivates and exits.
+	 *
+	 * This prevents a parse error when activated on older versions
+	 * of PHP or failures when activated on unsupported WP versions.
+	 *
+	 * @global $wp_version
+	 *
+	 * @uses $wp_version
+	 * @uses Admin_Language::get_minimum_wordpress_version()
+	 * @uses deactivate_plugins()
+	 * @uses plugin_basename()
+	 *
+	 * @return void
+	 */
+	public static function checkPrereqs() {
+		global $wp_version;
+		$min_wp_version = self::get_minimum_wordpress_version();
+		if ( version_compare($min_wp_version, $wp_version ) > 0 ) {
+			deactivate_plugins( plugin_basename( __FILE__ ) );
+			wp_die( sprintf(
+				__('Admin Language Per User requires at least WordPress version %1$s. You have WordPress version %2$s.', 'admin-language-per-user'),
+				$min_wp_version, $wp_version
+			));
+		}
+	}
+
+	/**
+	 * Returns the "Requires at least" value from plugin's readme.txt.
+	 *
+	 * @link https://wordpress.org/plugins/about/readme.txt WordPress readme.txt standard
+	 *
+	 * @return string
+	 */
+	public static function get_minimum_wordpress_version() {
+		$lines = @file( plugin_dir_path( __FILE__ ) . 'readme.txt' );
+		foreach ( $lines as $line ) {
+			preg_match( '/^Requires at least: ([0-9.]+)$/', $line, $m );
+			if ( $m ) {
+				return $m[1];
+			}
+		}
+	}
+
 	/**
 	 * Add the inputs to the User Profile page
 	 *
 	 * @param WP_User $user User instance to output for.
 	 */	
-	public static function user_profile($user) {
+	public static function user_profile( $user ) {
 		$languages = get_available_languages();
 		$translations = wp_get_available_translations();
 		
@@ -92,18 +164,19 @@ class Admin_Language {
 			$language = 'en_US';
 		}
 		update_user_meta( $user_id, self::meta_name, $language );
-	}	
+	}
+
 	/**
 	 * Add locale filter after plugins are loaded
-	 * 
+	 *
 	 */
 	public static function plugins_loaded() {
 		add_filter( 'locale', array(get_class(), 'locale') );
-		
 	}
+
 	/**
 	 * @link 	https://codex.wordpress.org/Plugin_API/Filter_Reference/locale
-	 * 
+	 *
 	 * @param   string $locale default site locale	
 	 * @return 	string new locale
 	 */	
@@ -112,18 +185,20 @@ class Admin_Language {
 			$admin_language = get_the_author_meta('admin_language', get_current_user_id());
 			return empty($admin_language) ? $locale : $admin_language;			
 		}
-		
+
 		return $locale;
 	}
+
 	/**
 	 * Frontend AJAX call check helper
 	 * @internal
 	 *
 	 * @return boolean
-	 */	
+	 */
 	private static function is_frontend_ajax() {
 		return defined( 'DOING_AJAX' ) && DOING_AJAX && false === strpos( wp_get_referer(), '/wp-admin/' );
 	}
+
 	/**
 	 * TinyMCE check helper
 	 * @internal

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,10 @@ No FAQ yet
 
 == Changelog ==
 
+= 1.0.1 =
+* Added `uninstall.php` to remove user meta options on uninstall.
+* Added activation-time check for minimum WordPress version.
+
 = 1.0 =
 * Initial version.
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Admin Language Per User uninstaller.
+ *
+ * @link https://developer.wordpress.org/plugins/the-basics/uninstall-methods/#uninstall-php
+ *
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * @copyright Copyright (c) 2016 by Unclego and Meitar Moscovitz
+ *
+ * @package admin_language_per_user\uninstaller
+ */
+
+namespace admin_language_per_user;
+
+// Don't execute any uninstall code unless WordPress core requests it.
+if (!defined('WP_UNINSTALL_PLUGIN')) { exit(); }
+
+require_once plugin_dir_path(__FILE__) . 'admin-language-per-user.php';
+
+foreach (get_users() as $usr) {
+    // Delete all custom user profile data.
+    delete_user_meta($usr->ID, Admin_Language::meta_name);
+}


### PR DESCRIPTION
This also cleans up some trailing whitespace in several lines, makes code style more consistent with WordPress core style guide, and adds a missing PHPDoc docblock.
